### PR TITLE
Class and Species updates

### DIFF
--- a/src/pojos/entity/enums/EntityClassEnum.java
+++ b/src/pojos/entity/enums/EntityClassEnum.java
@@ -4,12 +4,10 @@ public enum EntityClassEnum {
 	MAGE, 
 	WARRIOR,
 	THIEF,
-	ROGUE, // combine with thief
 	HUNTER,
 	DRUID,
 	BARD,
 	PALADIN,
-	CLERIC,
 	WIZARD,
 	PRIEST
 	// what about like a fairy or a spirit?


### PR DESCRIPTION
Added Class and Species info to the database for all class and specie enums.

Removed Rogue and Cleric, as they are effectively identical to the Thief and Priest.
Re #57 